### PR TITLE
Implement Journey Model with API, Persistence, and Tests

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -4,7 +4,7 @@ Simple and focused on the fare calculation use case.
 """
 from rest_framework import serializers
 from zones.models import Zone
-
+from fare.models import Journey
 
 class JourneyInputSerializer(serializers.Serializer):
     """
@@ -31,3 +31,51 @@ class FareRuleSerializer(serializers.Serializer):
     to_zone = serializers.IntegerField(read_only=True)
     fare = serializers.FloatField(read_only=True)
     route = serializers.CharField(read_only=True)
+
+class JourneySerializer(serializers.ModelSerializer):
+    """
+    Serializer for Journey model.
+    Returns journey with fare.
+    """
+    fare_display = serializers.IntegerField(read_only=True)
+    
+    class Meta:
+        model = Journey
+        fields = [
+            'id',
+            'user_id',
+            'from_zone',
+            'to_zone',
+            'fare',
+            'timestamp',
+
+        ]
+        read_only_fields = ['id', 'timestamp']
+    
+class JourneyCreateSerializer(serializers.ModelSerializer):
+    """
+    Serializer for creating a Journey.
+    """
+    class Meta:
+        model = Journey
+        fields = ['from_zone', 'to_zone', 'fare']
+
+
+class JourneyHistorySerializer(serializers.ModelSerializer):
+    """
+    Serializer for journey history listing.
+    """
+
+    class Meta:
+        model = Journey
+        fields = [
+            'id',
+            'user_id',
+            'from_zone',
+            'to_zone',
+            'fare',
+            'timestamp',
+
+        ]
+        read_only_fields = ['id', 'timestamp']
+

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -6,6 +6,7 @@ from .views import (
     CalculateFareAPIView,
     ZoneListAPIView,
     FareRulesAPIView,
+    JourneyHistoryAPIView,
 )
 
 app_name = 'api'
@@ -15,6 +16,7 @@ urlpatterns = [
     path('calculate-fare/', CalculateFareAPIView.as_view(), name='calculate-fare'),
     path('zones/', ZoneListAPIView.as_view(), name='zone-list'),
     path('fare-rules/', FareRulesAPIView.as_view(), name='fare-rules'),
+    path('journeys/', JourneyHistoryAPIView.as_view(), name='journey-history'),
 
 ]
 

--- a/backend/fare/fare_calculator.py
+++ b/backend/fare/fare_calculator.py
@@ -43,7 +43,7 @@ class SimpleFareCalculator:
     }
     
     @classmethod
-    def calculate_single_fare(cls, from_zone: int, to_zone: int) -> float:
+    def calculate_single_fare(cls, from_zone: int, to_zone: int) -> int:
         """
         Calculate fare for a single journey.
         
@@ -53,8 +53,8 @@ class SimpleFareCalculator:
             
         Returns:
                     {
-            "from_zone": 1,
-            "to_zone": 2,
+            "from_zone": "1",
+            "to_zone": "2",
             "fare": 55,
 
         }
@@ -70,16 +70,13 @@ class SimpleFareCalculator:
         
         # Same zone travel
         if from_zone == to_zone:
-            return {
-            'fare': cls.SAME_ZONE_FARES[from_zone],
-            }
+            return cls.SAME_ZONE_FARES[from_zone]
+        
         
         # Different zone travel (handle bidirectional by sorting)
         zone_pair = tuple(sorted([from_zone, to_zone]))
-        return {
-            'fare': cls.DIFFERENT_ZONE_FARES[zone_pair],
-        }
-    
+        return cls.DIFFERENT_ZONE_FARES[zone_pair]
+
     @classmethod
     def calculate_batch_fares(cls, journeys: List[Dict]) -> Dict:
         """

--- a/backend/fare/models.py
+++ b/backend/fare/models.py
@@ -1,3 +1,46 @@
 from django.db import models
+from django.core.validators import MinValueValidator, MaxValueValidator
 
-# Create your models here.
+
+class Journey(models.Model):
+    """
+    Model to store journey history and calculated fares.
+    Each record represents a single fare calculation request.
+    """
+    
+    # Using CharField for zones to match the requirement
+    # Could also use IntegerField if you prefer
+    user_id = models.CharField(
+        max_length=10,
+        help_text="user id"
+    )
+    from_zone = models.CharField(
+        max_length=10,
+        help_text="Starting zone number"
+    )
+    
+    to_zone = models.CharField(
+        max_length=10,
+        help_text="Destination zone number"
+    )
+    
+    fare = models.IntegerField(
+        validators=[MinValueValidator(0)],
+        help_text="Calculated fare amount (stored as integer)"
+    )
+    
+    timestamp = models.DateTimeField(
+        auto_now_add=True,
+        help_text="When the journey was calculated"
+    )
+    class Meta:
+        ordering = ['-timestamp']  # Most recent first
+        verbose_name = "Journey"
+        verbose_name_plural = "Journeys"
+        indexes = [
+            models.Index(fields=['-timestamp']),
+            models.Index(fields=['from_zone', 'to_zone']),
+        ]
+    
+    def __str__(self):
+        return f"Journey {self.id}: Zone {self.from_zone} → Zone {self.to_zone} (£{self.fare/100:.2f}) at {self.timestamp}"


### PR DESCRIPTION
## Summary
This PR introduces a new `Journey` model to keep track of fare calculation trips. Each API `POST` request to calculate a fare will now create and store a corresponding `Journey` entry in the database. This provides a persistent history of trips that can be queried later.

## Changes Made
- **Models**
  - Added `Journey` model to track:
    - from zone
    - to zone
    - fare 
    - Timestamp of the trip

- **Serializers**
  - Created `JourneySerializer` to handle JSON input/output.

- **Views / API**
  - Added API endpoint to:
    - Record each trip in the database upon fare calculation.
    - Retrieve a list of past journeys for history tracking.