### PR TITLE
Extend `CalculateFareAPIView` to handle multiple journeys

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -5,14 +5,29 @@ Simple and focused on the fare calculation use case.
 from rest_framework import serializers
 from zones.models import Zone
 from fare.models import Journey
-
 class JourneyInputSerializer(serializers.Serializer):
     """
     Validates a single journey input.
     """
-    user_id = serializers.CharField(required=True)
     from_zone = serializers.CharField(required=True)
     to_zone = serializers.CharField(required=True)
+
+class JourneyCalculationSerializer(serializers.Serializer):
+    """Serializer for fare calculation request"""
+    user_id = serializers.CharField(required=True)
+    journeys = JourneyInputSerializer(many=True, max_length=20)
+class JourneyResultSerializer(serializers.Serializer):
+    """Serializer for journey with calculated fare"""
+    from_zone = serializers.IntegerField()
+    to_zone = serializers.IntegerField()
+    fare = serializers.IntegerField()
+    error = serializers.CharField(required=False)
+class FareCalculationResponseSerializer(serializers.Serializer):
+    """Serializer for fare calculation response"""
+    journeys = JourneyResultSerializer(many=True)
+    total_fare = serializers.IntegerField()
+    journey_count = serializers.IntegerField()
+    user_id = serializers.CharField(required=False)
 
 class ZoneSerializer(serializers.ModelSerializer):
     """

--- a/backend/fare/fare_calculator.py
+++ b/backend/fare/fare_calculator.py
@@ -107,7 +107,7 @@ class SimpleFareCalculator:
             journeys = journeys[:20]
         
         results = []
-        fare = 0.0
+        total_fare = 0
         
         for idx, journey in enumerate(journeys, 1):
             try:
@@ -130,7 +130,7 @@ class SimpleFareCalculator:
                     'fare': fare,
                     'status': 'success'
                 })
-                fare += fare
+                total_fare += fare
                 
             except (ValueError, TypeError, KeyError) as e:
                 # Handle errors gracefully
@@ -145,7 +145,7 @@ class SimpleFareCalculator:
         
         return {
             'journeys': results,
-            'fare': round(fare, 2),
+            'total_fare': total_fare,
             'journey_count': len(results)
         }
     


### PR DESCRIPTION
Extend `CalculateFareAPIView` to handle multiple journeys

### Summary
This PR enhances the backend fare calculation API to support **batch journey requests**.  
Instead of handling only a single `from_zone` → `to_zone` request, the endpoint now accepts a list of journeys and responds with both **individual trip fares** and the **total fare**.

### Changes
- 🔄 Updated `CalculateFareAPIView`:
  - Accepts a list of journeys (each with `from_zone` and `to_zone`)
  - Iterates through each journey and calculates fares
  - Aggregates the **total fare** across all journeys